### PR TITLE
Minor change to 'Listing Block' to make it easier to use with other languages

### DIFF
--- a/Snippets/Listing Block.tmSnippet
+++ b/Snippets/Listing Block.tmSnippet
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>[source,scala]
-----------------------------------------------------------------------
-$1
-----------------------------------------------------------------------
+	<string>[source,$1]
+----
+$2
+----
 $0</string>
 	<key>name</key>
 	<string>Listing Block</string>


### PR DESCRIPTION
- removed ‘scala’; replaced with tab stop
- shortened block delimiter to four hyphens
