### PR TITLE
Explicit count modifiers

### DIFF
--- a/Syntaxes/AsciiDoc.tmLanguage
+++ b/Syntaxes/AsciiDoc.tmLanguage
@@ -70,14 +70,14 @@
 				(?=	([/+-.*_=]{4,})\s*$
 				|	([ \t]{1,})
 				|	[=]{1,6}\s*+
-				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$
+				|	[ ]{0,3}(?&lt;marker&gt;[-*_])([ ]{0,2}\k&lt;marker&gt;){2,}[ \t]*+$
 				)</string>
 			<key>end</key>
 			<string>(?x)^
 				(?!	\1
 				|	([ \t]{1,})
 				|	[=]{1,6}\s*+
-				|	[ ]{,3}(?&lt;marker&gt;[-*_])([ ]{,2}\k&lt;marker&gt;){2,}[ \t]*+$
+				|	[ ]{0,3}(?&lt;marker&gt;[-*_])([ ]{0,2}\k&lt;marker&gt;){2,}[ \t]*+$
 				)</string>
 			<key>name</key>
 			<string>meta.block-level.asciidoc</string>
@@ -175,7 +175,7 @@
 			<key>begin</key>
 			<string>^(?=\S)(?![=-]{3,}(?=$))(?!\.\S+)</string>
 			<key>end</key>
-			<string>^(?:\s*$|(?=[ ]{,3}&gt;.))|(?=[ \t]*\n)(?&lt;=^===|^====|=====|^---|^----|-----)[ \t]*\n</string>
+			<string>^(?:\s*$|(?=[ ]{0,3}&gt;.))|(?=[ \t]*\n)(?&lt;=^===|^====|=====|^---|^----|-----)[ \t]*\n</string>
 			<key>name</key>
 			<string>meta.paragraph.asciidoc</string>
 			<key>patterns</key>
@@ -612,7 +612,7 @@
 		<key>separator</key>
 		<dict>
 			<key>match</key>
-			<string>\G[ ]{,3}([-*_])([ ]{,2}\1){2,}[ \t]*$\n?</string>
+			<string>\G[ ]{0,3}([-*_])([ ]{0,2}\1){2,}[ \t]*$\n?</string>
 			<key>name</key>
 			<string>meta.separator.asciidoc</string>
 		</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by TextMate). This package is used to highlight AsciiDoc code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes.

This pull request fixes that by using an explicit count modifier in regular expressions.